### PR TITLE
feat: implement semantic error codes for auth (front + back)

### DIFF
--- a/apps/api/src/middleware/authMiddleware.ts
+++ b/apps/api/src/middleware/authMiddleware.ts
@@ -30,7 +30,7 @@ export const authMiddleware = (
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    res.status(401).json({ message: "Token d'autenticació no proporcionat" });
+    res.status(401).json({ errorCode: "AUTH_TOKEN_MISSING" });
     return;
   }
 
@@ -41,6 +41,6 @@ export const authMiddleware = (
     req.userId = decoded.userId;
     next();
   } catch {
-    res.status(401).json({ message: "Token d'autenticació invàlid o caducat" });
+    res.status(401).json({ errorCode: "AUTH_TOKEN_INVALID" });
   }
 };

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -3,9 +3,10 @@
 
 import { Request, Response, NextFunction } from "express";
 
-// Interfície per a errors amb codi HTTP personalitzat
+// Interfície per a errors amb codi HTTP personalitzat i codi semàntic
 export interface AppError extends Error {
   statusCode?: number;
+  errorCode?: string;
 }
 
 export const errorHandler = (
@@ -17,11 +18,11 @@ export const errorHandler = (
 ): void => {
   const statusCode = err.statusCode ?? 500;
 
-  // Ocultar detalls interns dels errors 500 a producció
-  const message =
+  // Els errors 500 en producció s'amaguen darrere un codi genèric
+  const errorCode =
     statusCode === 500 && process.env.NODE_ENV === "production"
-      ? "Error intern del servidor"
-      : (err.message ?? "Error desconegut");
+      ? "INTERNAL_ERROR"
+      : (err.errorCode ?? "UNKNOWN_ERROR");
 
-  res.status(statusCode).json({ message });
+  res.status(statusCode).json({ errorCode });
 };

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -33,10 +33,10 @@ export const register = async (
   try {
     const parsed = registerSchema.safeParse(req.body);
     if (!parsed.success) {
-      const error = new Error(
-        parsed.error.errors[0]?.message ?? "Dades invàlides"
-      ) as AppError;
+      const errorCode = parsed.error.errors[0]?.message ?? "INVALID_DATA";
+      const error = new Error(errorCode) as AppError;
       error.statusCode = 400;
+      error.errorCode = errorCode;
       return next(error);
     }
 
@@ -59,10 +59,10 @@ export const login = async (
   try {
     const parsed = loginSchema.safeParse(req.body);
     if (!parsed.success) {
-      const error = new Error(
-        parsed.error.errors[0]?.message ?? "Dades invàlides"
-      ) as AppError;
+      const errorCode = parsed.error.errors[0]?.message ?? "INVALID_DATA";
+      const error = new Error(errorCode) as AppError;
       error.statusCode = 400;
+      error.errorCode = errorCode;
       return next(error);
     }
 
@@ -87,8 +87,9 @@ export const refresh = (
       req.cookies[REFRESH_TOKEN_COOKIE_NAME] as string | undefined;
 
     if (!token) {
-      const error = new Error("Token de refresc no trobat") as AppError;
+      const error = new Error("REFRESH_TOKEN_MISSING") as AppError;
       error.statusCode = 401;
+      error.errorCode = "REFRESH_TOKEN_MISSING";
       return next(error);
     }
 

--- a/apps/api/src/modules/auth/service.ts
+++ b/apps/api/src/modules/auth/service.ts
@@ -54,10 +54,9 @@ export const registerUser = async (
   // Comprovar si ja existeix un usuari amb aquest email
   const existing = await UserModel.findOne({ email: input.email });
   if (existing) {
-    const error = new Error(
-      "Aquest correu electrònic ja està registrat"
-    ) as AppError;
+    const error = new Error("EMAIL_ALREADY_EXISTS") as AppError;
     error.statusCode = 409;
+    error.errorCode = "EMAIL_ALREADY_EXISTS";
     throw error;
   }
 
@@ -77,9 +76,10 @@ export const registerUser = async (
 export const loginUser = async (input: LoginInput): Promise<AuthTokens> => {
   const user: IUser | null = await UserModel.findOne({ email: input.email });
 
-  // Missatge genèric intencionat — no revela si l'email existeix
-  const invalidError = new Error("Credencials incorrectes") as AppError;
+  // Codi genèric intencionat — no revela si l'email existeix o no
+  const invalidError = new Error("INVALID_CREDENTIALS") as AppError;
   invalidError.statusCode = 401;
+  invalidError.errorCode = "INVALID_CREDENTIALS";
 
   if (!user) {
     // Hash fictici per evitar timing attacks (bcrypt.compare és lent)
@@ -107,19 +107,21 @@ export const refreshTokens = (refreshToken: string): AuthTokens => {
 
     // Verificar que és realment un refresh token (no un access token reutilitzat)
     if (payload.type !== "refresh") {
-      const error = new Error("Token de refresc invàlid") as AppError;
+      const error = new Error("INVALID_REFRESH_TOKEN") as AppError;
       error.statusCode = 401;
+      error.errorCode = "INVALID_REFRESH_TOKEN";
       throw error;
     }
 
     return generateTokens(payload.userId);
   } catch (err) {
-    // Si ja és un AppError amb statusCode, el relancem directament
-    if ((err as AppError).statusCode) {
+    // Si ja és un AppError amb errorCode, el relancem directament
+    if ((err as AppError).errorCode) {
       throw err;
     }
-    const error = new Error("Token de refresc invàlid o caducat") as AppError;
+    const error = new Error("REFRESH_TOKEN_EXPIRED") as AppError;
     error.statusCode = 401;
+    error.errorCode = "REFRESH_TOKEN_EXPIRED";
     throw error;
   }
 };

--- a/apps/api/src/modules/auth/validators.ts
+++ b/apps/api/src/modules/auth/validators.ts
@@ -4,27 +4,28 @@
 import { z } from "zod";
 
 // Esquema de registre — email normalitzat a minúscules, contrasenya mínima 8 caràcters
+// Els missatges Zod usen codis d'error semàntics per facilitar la traducció al frontend
 export const registerSchema = z.object({
   email: z
-    .string({ required_error: "El correu electrònic és obligatori" })
-    .email("Format de correu electrònic invàlid")
+    .string({ required_error: "EMAIL_REQUIRED" })
+    .email("EMAIL_INVALID_FORMAT")
     .transform((v) => v.toLowerCase().trim()),
   password: z
-    .string({ required_error: "La contrasenya és obligatòria" })
-    .min(8, "La contrasenya ha de tenir mínim 8 caràcters")
-    .max(128, "La contrasenya no pot superar els 128 caràcters"),
+    .string({ required_error: "PASSWORD_REQUIRED" })
+    .min(8, "PASSWORD_TOO_SHORT")
+    .max(128, "PASSWORD_TOO_LONG"),
 });
 
 // Esquema de login — contrasenya sense validació de longitud mínima per no revelar regles
-// Si l'usuari introdueix una contrasenya curta, ha de rebre "credencials incorrectes"
+// Si l'usuari introdueix una contrasenya curta, ha de rebre INVALID_CREDENTIALS
 export const loginSchema = z.object({
   email: z
-    .string({ required_error: "El correu electrònic és obligatori" })
-    .email("Format de correu electrònic invàlid")
+    .string({ required_error: "EMAIL_REQUIRED" })
+    .email("EMAIL_INVALID_FORMAT")
     .transform((v) => v.toLowerCase().trim()),
   password: z
-    .string({ required_error: "La contrasenya és obligatòria" })
-    .min(1, "La contrasenya és obligatòria"),
+    .string({ required_error: "PASSWORD_REQUIRED" })
+    .min(1, "PASSWORD_REQUIRED"),
 });
 
 // Tipus inferits dels esquemes — usats al controller i service

--- a/apps/web/languages/ca.json
+++ b/apps/web/languages/ca.json
@@ -1071,6 +1071,46 @@
     "defaultMessage": "Ja tens compte? Inicia sessió",
     "description": "Enllaç per tornar al formulari de login"
   },
+  "features.backend.auth.error.INVALID_CREDENTIALS": {
+    "defaultMessage": "Correu electrònic o contrasenya incorrectes",
+    "description": "Error de login: credencials incorrectes"
+  },
+  "features.backend.auth.error.EMAIL_ALREADY_EXISTS": {
+    "defaultMessage": "Aquest correu electrònic ja està registrat",
+    "description": "Error de registre: email ja existent"
+  },
+  "features.backend.auth.error.EMAIL_REQUIRED": {
+    "defaultMessage": "El correu electrònic és obligatori",
+    "description": "Validació: camp email buit"
+  },
+  "features.backend.auth.error.EMAIL_INVALID_FORMAT": {
+    "defaultMessage": "El format del correu electrònic no és vàlid",
+    "description": "Validació: format d'email incorrecte"
+  },
+  "features.backend.auth.error.PASSWORD_REQUIRED": {
+    "defaultMessage": "La contrasenya és obligatòria",
+    "description": "Validació: camp contrasenya buit"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_SHORT": {
+    "defaultMessage": "La contrasenya ha de tenir com a mínim 8 caràcters",
+    "description": "Validació: contrasenya massa curta (registre)"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_LONG": {
+    "defaultMessage": "La contrasenya no pot superar els 128 caràcters",
+    "description": "Validació: contrasenya massa llarga (registre)"
+  },
+  "features.backend.auth.error.AUTH_ERROR": {
+    "defaultMessage": "S'ha produït un error en iniciar sessió. Torna-ho a intentar.",
+    "description": "Error genèric de login"
+  },
+  "features.backend.auth.error.REGISTER_ERROR": {
+    "defaultMessage": "S'ha produït un error en crear el compte. Torna-ho a intentar.",
+    "description": "Error genèric de registre"
+  },
+  "features.backend.auth.error.UNKNOWN_ERROR": {
+    "defaultMessage": "S'ha produït un error inesperat. Torna-ho a intentar.",
+    "description": "Error desconegut del servidor"
+  },
   "features.backend.auth.close": {
     "defaultMessage": "Tancar",
     "description": "Botó per tancar el modal d'autenticació"

--- a/apps/web/languages/en.json
+++ b/apps/web/languages/en.json
@@ -1071,6 +1071,46 @@
     "defaultMessage": "Have account? Sign in",
     "description": "Enllaç per tornar al formulari de login"
   },
+  "features.backend.auth.error.INVALID_CREDENTIALS": {
+    "defaultMessage": "Incorrect email address or password",
+    "description": "Error de login: credencials incorrectes"
+  },
+  "features.backend.auth.error.EMAIL_ALREADY_EXISTS": {
+    "defaultMessage": "This email address is already registered",
+    "description": "Error de registre: email ja existent"
+  },
+  "features.backend.auth.error.EMAIL_REQUIRED": {
+    "defaultMessage": "Email address is required",
+    "description": "Validació: camp email buit"
+  },
+  "features.backend.auth.error.EMAIL_INVALID_FORMAT": {
+    "defaultMessage": "The email address format is not valid",
+    "description": "Validació: format d'email incorrecte"
+  },
+  "features.backend.auth.error.PASSWORD_REQUIRED": {
+    "defaultMessage": "Password is required",
+    "description": "Validació: camp contrasenya buit"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_SHORT": {
+    "defaultMessage": "Password must be at least 8 characters",
+    "description": "Validació: contrasenya massa curta (registre)"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_LONG": {
+    "defaultMessage": "Password cannot exceed 128 characters",
+    "description": "Validació: contrasenya massa llarga (registre)"
+  },
+  "features.backend.auth.error.AUTH_ERROR": {
+    "defaultMessage": "An error occurred while signing in. Please try again.",
+    "description": "Error genèric de login"
+  },
+  "features.backend.auth.error.REGISTER_ERROR": {
+    "defaultMessage": "An error occurred while creating your account. Please try again.",
+    "description": "Error genèric de registre"
+  },
+  "features.backend.auth.error.UNKNOWN_ERROR": {
+    "defaultMessage": "An unexpected error occurred. Please try again.",
+    "description": "Error desconegut del servidor"
+  },
   "features.backend.auth.close": {
     "defaultMessage": "Close",
     "description": "Botó per tancar el modal d'autenticació"

--- a/apps/web/languages/es.json
+++ b/apps/web/languages/es.json
@@ -1071,6 +1071,46 @@
     "defaultMessage": "¿Ya tienes cuenta? Inicia sesión",
     "description": "Enllaç per tornar al formulari de login"
   },
+  "features.backend.auth.error.INVALID_CREDENTIALS": {
+    "defaultMessage": "Correo electrónico o contraseña incorrectos",
+    "description": "Error de login: credencials incorrectes"
+  },
+  "features.backend.auth.error.EMAIL_ALREADY_EXISTS": {
+    "defaultMessage": "Este correo electrónico ya está registrado",
+    "description": "Error de registre: email ja existent"
+  },
+  "features.backend.auth.error.EMAIL_REQUIRED": {
+    "defaultMessage": "El correo electrónico es obligatorio",
+    "description": "Validació: camp email buit"
+  },
+  "features.backend.auth.error.EMAIL_INVALID_FORMAT": {
+    "defaultMessage": "El formato del correo electrónico no es válido",
+    "description": "Validació: format d'email incorrecte"
+  },
+  "features.backend.auth.error.PASSWORD_REQUIRED": {
+    "defaultMessage": "La contraseña es obligatoria",
+    "description": "Validació: camp contrasenya buit"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_SHORT": {
+    "defaultMessage": "La contraseña debe tener al menos 8 caracteres",
+    "description": "Validació: contrasenya massa curta (registre)"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_LONG": {
+    "defaultMessage": "La contraseña no puede superar los 128 caracteres",
+    "description": "Validació: contrasenya massa llarga (registre)"
+  },
+  "features.backend.auth.error.AUTH_ERROR": {
+    "defaultMessage": "Se ha producido un error al iniciar sesión. Inténtalo de nuevo.",
+    "description": "Error genèric de login"
+  },
+  "features.backend.auth.error.REGISTER_ERROR": {
+    "defaultMessage": "Se ha producido un error al crear la cuenta. Inténtalo de nuevo.",
+    "description": "Error genèric de registre"
+  },
+  "features.backend.auth.error.UNKNOWN_ERROR": {
+    "defaultMessage": "Se ha producido un error inesperado. Inténtalo de nuevo.",
+    "description": "Error desconegut del servidor"
+  },
   "features.backend.auth.close": {
     "defaultMessage": "Cerrar",
     "description": "Botó per tancar el modal d'autenticació"

--- a/apps/web/languages/fr.json
+++ b/apps/web/languages/fr.json
@@ -1038,5 +1038,45 @@
   },
   "view.editSequences.sequences.label": {
     "defaultMessage": "Séquences"
+  },
+  "features.backend.auth.error.INVALID_CREDENTIALS": {
+    "defaultMessage": "Adresse e-mail ou mot de passe incorrect",
+    "description": "Error de login: credencials incorrectes"
+  },
+  "features.backend.auth.error.EMAIL_ALREADY_EXISTS": {
+    "defaultMessage": "Cette adresse e-mail est déjà enregistrée",
+    "description": "Error de registre: email ja existent"
+  },
+  "features.backend.auth.error.EMAIL_REQUIRED": {
+    "defaultMessage": "L'adresse e-mail est obligatoire",
+    "description": "Validació: camp email buit"
+  },
+  "features.backend.auth.error.EMAIL_INVALID_FORMAT": {
+    "defaultMessage": "Le format de l'adresse e-mail n'est pas valide",
+    "description": "Validació: format d'email incorrecte"
+  },
+  "features.backend.auth.error.PASSWORD_REQUIRED": {
+    "defaultMessage": "Le mot de passe est obligatoire",
+    "description": "Validació: camp contrasenya buit"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_SHORT": {
+    "defaultMessage": "Le mot de passe doit contenir au moins 8 caractères",
+    "description": "Validació: contrasenya massa curta (registre)"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_LONG": {
+    "defaultMessage": "Le mot de passe ne peut pas dépasser 128 caractères",
+    "description": "Validació: contrasenya massa llarga (registre)"
+  },
+  "features.backend.auth.error.AUTH_ERROR": {
+    "defaultMessage": "Une erreur s'est produite lors de la connexion. Veuillez réessayer.",
+    "description": "Error genèric de login"
+  },
+  "features.backend.auth.error.REGISTER_ERROR": {
+    "defaultMessage": "Une erreur s'est produite lors de la création du compte. Veuillez réessayer.",
+    "description": "Error genèric de registre"
+  },
+  "features.backend.auth.error.UNKNOWN_ERROR": {
+    "defaultMessage": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+    "description": "Error desconegut del servidor"
   }
 }

--- a/apps/web/languages/it.json
+++ b/apps/web/languages/it.json
@@ -1038,5 +1038,45 @@
   },
   "view.editSequences.sequences.label": {
     "defaultMessage": "Sequenze"
+  },
+  "features.backend.auth.error.INVALID_CREDENTIALS": {
+    "defaultMessage": "Indirizzo e-mail o password errati",
+    "description": "Error de login: credencials incorrectes"
+  },
+  "features.backend.auth.error.EMAIL_ALREADY_EXISTS": {
+    "defaultMessage": "Questo indirizzo e-mail è già registrato",
+    "description": "Error de registre: email ja existent"
+  },
+  "features.backend.auth.error.EMAIL_REQUIRED": {
+    "defaultMessage": "L'indirizzo e-mail è obbligatorio",
+    "description": "Validació: camp email buit"
+  },
+  "features.backend.auth.error.EMAIL_INVALID_FORMAT": {
+    "defaultMessage": "Il formato dell'indirizzo e-mail non è valido",
+    "description": "Validació: format d'email incorrecte"
+  },
+  "features.backend.auth.error.PASSWORD_REQUIRED": {
+    "defaultMessage": "La password è obbligatoria",
+    "description": "Validació: camp contrasenya buit"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_SHORT": {
+    "defaultMessage": "La password deve contenere almeno 8 caratteri",
+    "description": "Validació: contrasenya massa curta (registre)"
+  },
+  "features.backend.auth.error.PASSWORD_TOO_LONG": {
+    "defaultMessage": "La password non può superare i 128 caratteri",
+    "description": "Validació: contrasenya massa llarga (registre)"
+  },
+  "features.backend.auth.error.AUTH_ERROR": {
+    "defaultMessage": "Si è verificato un errore durante l'accesso. Riprova.",
+    "description": "Error genèric de login"
+  },
+  "features.backend.auth.error.REGISTER_ERROR": {
+    "defaultMessage": "Si è verificato un errore durante la creazione dell'account. Riprova.",
+    "description": "Error genèric de registre"
+  },
+  "features.backend.auth.error.UNKNOWN_ERROR": {
+    "defaultMessage": "Si è verificato un errore imprevisto. Riprova.",
+    "description": "Error desconegut del servidor"
   }
 }

--- a/apps/web/src/features/backend/auth/components/AuthModal.lang.ts
+++ b/apps/web/src/features/backend/auth/components/AuthModal.lang.ts
@@ -102,6 +102,58 @@ const messages = defineMessages({
     defaultMessage: "Carrega",
     description: "Botó per carregar un document seleccionat del backend",
   },
+
+  // Errors retornats pel backend com a codis semàntics
+  INVALID_CREDENTIALS: {
+    id: "features.backend.auth.error.INVALID_CREDENTIALS",
+    defaultMessage: "Correu electrònic o contrasenya incorrectes",
+    description: "Error de login: credencials incorrectes",
+  },
+  EMAIL_ALREADY_EXISTS: {
+    id: "features.backend.auth.error.EMAIL_ALREADY_EXISTS",
+    defaultMessage: "Aquest correu electrònic ja està registrat",
+    description: "Error de registre: email ja existent",
+  },
+  EMAIL_REQUIRED: {
+    id: "features.backend.auth.error.EMAIL_REQUIRED",
+    defaultMessage: "El correu electrònic és obligatori",
+    description: "Validació: camp email buit",
+  },
+  EMAIL_INVALID_FORMAT: {
+    id: "features.backend.auth.error.EMAIL_INVALID_FORMAT",
+    defaultMessage: "El format del correu electrònic no és vàlid",
+    description: "Validació: format d'email incorrecte",
+  },
+  PASSWORD_REQUIRED: {
+    id: "features.backend.auth.error.PASSWORD_REQUIRED",
+    defaultMessage: "La contrasenya és obligatòria",
+    description: "Validació: camp contrasenya buit",
+  },
+  PASSWORD_TOO_SHORT: {
+    id: "features.backend.auth.error.PASSWORD_TOO_SHORT",
+    defaultMessage: "La contrasenya ha de tenir com a mínim 8 caràcters",
+    description: "Validació: contrasenya massa curta (registre)",
+  },
+  PASSWORD_TOO_LONG: {
+    id: "features.backend.auth.error.PASSWORD_TOO_LONG",
+    defaultMessage: "La contrasenya no pot superar els 128 caràcters",
+    description: "Validació: contrasenya massa llarga (registre)",
+  },
+  AUTH_ERROR: {
+    id: "features.backend.auth.error.AUTH_ERROR",
+    defaultMessage: "S'ha produït un error en iniciar sessió. Torna-ho a intentar.",
+    description: "Error genèric de login",
+  },
+  REGISTER_ERROR: {
+    id: "features.backend.auth.error.REGISTER_ERROR",
+    defaultMessage: "S'ha produït un error en crear el compte. Torna-ho a intentar.",
+    description: "Error genèric de registre",
+  },
+  UNKNOWN_ERROR: {
+    id: "features.backend.auth.error.UNKNOWN_ERROR",
+    defaultMessage: "S'ha produït un error inesperat. Torna-ho a intentar.",
+    description: "Error desconegut del servidor",
+  },
 });
 
 export default messages;

--- a/apps/web/src/features/backend/auth/components/AuthModal.tsx
+++ b/apps/web/src/features/backend/auth/components/AuthModal.tsx
@@ -27,7 +27,14 @@ interface AuthModalProps {
 const AuthModal = ({ open, onClose }: AuthModalProps): React.ReactElement => {
   const intl = useIntl();
   const dispatch = useAppDispatch();
-  const { isLoading, error } = useAppSelector((state) => state.auth);
+  const { isLoading, errorCode } = useAppSelector((state) => state.auth);
+
+  // Tradueix el codi d'error del backend al missatge de l'idioma actiu
+  const errorMessage = errorCode
+    ? intl.formatMessage(
+        messages[errorCode as keyof typeof messages] ?? messages.UNKNOWN_ERROR,
+      )
+    : null;
 
   const [isRegisterMode, setIsRegisterMode] = useState(false);
   const [email, setEmail] = useState("");
@@ -91,9 +98,9 @@ const AuthModal = ({ open, onClose }: AuthModalProps): React.ReactElement => {
           noValidate
           sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}
         >
-          {error && (
+          {errorMessage && (
             <Alert severity="error" variant="outlined">
-              {error}
+              {errorMessage}
             </Alert>
           )}
 

--- a/apps/web/src/features/backend/auth/store/authSlice.ts
+++ b/apps/web/src/features/backend/auth/store/authSlice.ts
@@ -16,14 +16,14 @@ export interface AuthState {
   accessToken: string | null;
   userEmail: string | null;
   isLoading: boolean;
-  error: string | null;
+  errorCode: string | null;
 }
 
 const initialState: AuthState = {
   accessToken: null,
   userEmail: null,
   isLoading: false,
-  error: null,
+  errorCode: null,
 };
 
 // Sincronitza les settings del backend amb el store local + storage
@@ -60,10 +60,10 @@ export const loginThunk = createAsyncThunk(
       await syncSettingsAfterAuth(dispatch);
       return { accessToken, email };
     } catch (error: unknown) {
-      const message =
-        (error as { response?: { data?: { message?: string } } })?.response
-          ?.data?.message ?? "Error d'autenticació";
-      return rejectWithValue(message);
+      const errorCode =
+        (error as { response?: { data?: { errorCode?: string } } })?.response
+          ?.data?.errorCode ?? "AUTH_ERROR";
+      return rejectWithValue(errorCode);
     }
   },
 );
@@ -81,10 +81,10 @@ export const registerThunk = createAsyncThunk(
       await syncSettingsAfterAuth(dispatch);
       return { accessToken, email };
     } catch (error: unknown) {
-      const message =
-        (error as { response?: { data?: { message?: string } } })?.response
-          ?.data?.message ?? "Error en el registre";
-      return rejectWithValue(message);
+      const errorCode =
+        (error as { response?: { data?: { errorCode?: string } } })?.response
+          ?.data?.errorCode ?? "REGISTER_ERROR";
+      return rejectWithValue(errorCode);
     }
   },
 );
@@ -130,7 +130,7 @@ const authSlice = createSlice({
     clearAuthState: (state) => {
       state.accessToken = null;
       state.userEmail = null;
-      state.error = null;
+      state.errorCode = null;
     },
   },
   extraReducers: (builder) => {
@@ -138,7 +138,7 @@ const authSlice = createSlice({
     builder
       .addCase(loginThunk.pending, (state) => {
         state.isLoading = true;
-        state.error = null;
+        state.errorCode = null;
       })
       .addCase(
         loginThunk.fulfilled,
@@ -150,14 +150,14 @@ const authSlice = createSlice({
       )
       .addCase(loginThunk.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
+        state.errorCode = action.payload as string;
       });
 
     // Register
     builder
       .addCase(registerThunk.pending, (state) => {
         state.isLoading = true;
-        state.error = null;
+        state.errorCode = null;
       })
       .addCase(
         registerThunk.fulfilled,
@@ -169,7 +169,7 @@ const authSlice = createSlice({
       )
       .addCase(registerThunk.rejected, (state, action) => {
         state.isLoading = false;
-        state.error = action.payload as string;
+        state.errorCode = action.payload as string;
       });
 
     // Logout
@@ -177,7 +177,7 @@ const authSlice = createSlice({
       .addCase(logoutThunk.fulfilled, (state) => {
         state.accessToken = null;
         state.userEmail = null;
-        state.error = null;
+        state.errorCode = null;
       });
 
     // Refresh silent


### PR DESCRIPTION
Replace hardcoded text messages with semantic error codes (INVALID_CREDENTIALS, EMAIL_ALREADY_EXISTS, PASSWORD_TOO_SHORT, etc.) in the API. The frontend maps codes to translated messages via react-intl in 5 languages (ca, es, en, fr, it).