### PR TITLE
feat: add fr and it translations for auth modal

### DIFF
--- a/apps/web/languages/fr.json
+++ b/apps/web/languages/fr.json
@@ -1039,6 +1039,86 @@
   "view.editSequences.sequences.label": {
     "defaultMessage": "Séquences"
   },
+  "features.backend.auth.loginTitle": {
+    "defaultMessage": "Se connecter",
+    "description": "Títol del formulari de login"
+  },
+  "features.backend.auth.registerTitle": {
+    "defaultMessage": "Créer un compte",
+    "description": "Títol del formulari de registre"
+  },
+  "features.backend.auth.email": {
+    "defaultMessage": "Adresse e-mail",
+    "description": "Etiqueta del camp email"
+  },
+  "features.backend.auth.password": {
+    "defaultMessage": "Mot de passe",
+    "description": "Etiqueta del camp contrasenya"
+  },
+  "features.backend.auth.submitLogin": {
+    "defaultMessage": "Connexion",
+    "description": "Botó per enviar el formulari de login"
+  },
+  "features.backend.auth.submitRegister": {
+    "defaultMessage": "S'inscrire",
+    "description": "Botó per enviar el formulari de registre"
+  },
+  "features.backend.auth.toggleToRegister": {
+    "defaultMessage": "Pas de compte ? Inscrivez-vous",
+    "description": "Enllaç per canviar al formulari de registre"
+  },
+  "features.backend.auth.toggleToLogin": {
+    "defaultMessage": "Déjà un compte ? Connectez-vous",
+    "description": "Enllaç per tornar al formulari de login"
+  },
+  "features.backend.auth.close": {
+    "defaultMessage": "Fermer",
+    "description": "Botó per tancar el modal d'autenticació"
+  },
+  "features.backend.auth.showPassword": {
+    "defaultMessage": "Afficher le mot de passe",
+    "description": "Etiqueta ARIA per al botó de mostrar/amagar contrasenya"
+  },
+  "features.backend.auth.loginItem": {
+    "defaultMessage": "Se connecter",
+    "description": "Ítem del drawer per obrir el modal de login"
+  },
+  "features.backend.auth.saveDocument": {
+    "defaultMessage": "Enregistrer dans le cloud",
+    "description": "Ítem del drawer per desar el document al backend"
+  },
+  "features.backend.auth.loadDocument": {
+    "defaultMessage": "Charger depuis le cloud",
+    "description": "Ítem del drawer per carregar un document del backend"
+  },
+  "features.backend.auth.logout": {
+    "defaultMessage": "Se déconnecter",
+    "description": "Ítem del drawer per tancar la sessió"
+  },
+  "features.backend.auth.documentSaved": {
+    "defaultMessage": "Document enregistré dans le cloud",
+    "description": "Missatge de confirmació quan el document es desa al backend"
+  },
+  "features.backend.auth.documentLoaded": {
+    "defaultMessage": "Document chargé",
+    "description": "Missatge de confirmació quan es carrega un document del backend"
+  },
+  "features.backend.auth.loadDocumentTitle": {
+    "defaultMessage": "Charger un document",
+    "description": "Títol del modal de càrrega de documents del backend"
+  },
+  "features.backend.auth.noDocuments": {
+    "defaultMessage": "Vous n'avez aucun document enregistré",
+    "description": "Missatge quan l'usuari no té documents al backend"
+  },
+  "features.backend.auth.deleteDocument": {
+    "defaultMessage": "Supprimer",
+    "description": "Botó per eliminar un document del backend"
+  },
+  "features.backend.auth.loadAction": {
+    "defaultMessage": "Charger",
+    "description": "Botó per carregar un document seleccionat del backend"
+  },
   "features.backend.auth.error.INVALID_CREDENTIALS": {
     "defaultMessage": "Adresse e-mail ou mot de passe incorrect",
     "description": "Error de login: credencials incorrectes"

--- a/apps/web/languages/it.json
+++ b/apps/web/languages/it.json
@@ -1039,6 +1039,86 @@
   "view.editSequences.sequences.label": {
     "defaultMessage": "Sequenze"
   },
+  "features.backend.auth.loginTitle": {
+    "defaultMessage": "Accedi",
+    "description": "Títol del formulari de login"
+  },
+  "features.backend.auth.registerTitle": {
+    "defaultMessage": "Crea un account",
+    "description": "Títol del formulari de registre"
+  },
+  "features.backend.auth.email": {
+    "defaultMessage": "Indirizzo e-mail",
+    "description": "Etiqueta del camp email"
+  },
+  "features.backend.auth.password": {
+    "defaultMessage": "Password",
+    "description": "Etiqueta del camp contrasenya"
+  },
+  "features.backend.auth.submitLogin": {
+    "defaultMessage": "Accedi",
+    "description": "Botó per enviar el formulari de login"
+  },
+  "features.backend.auth.submitRegister": {
+    "defaultMessage": "Registrati",
+    "description": "Botó per enviar el formulari de registre"
+  },
+  "features.backend.auth.toggleToRegister": {
+    "defaultMessage": "Non hai un account? Registrati",
+    "description": "Enllaç per canviar al formulari de registre"
+  },
+  "features.backend.auth.toggleToLogin": {
+    "defaultMessage": "Hai già un account? Accedi",
+    "description": "Enllaç per tornar al formulari de login"
+  },
+  "features.backend.auth.close": {
+    "defaultMessage": "Chiudi",
+    "description": "Botó per tancar el modal d'autenticació"
+  },
+  "features.backend.auth.showPassword": {
+    "defaultMessage": "Mostra la password",
+    "description": "Etiqueta ARIA per al botó de mostrar/amagar contrasenya"
+  },
+  "features.backend.auth.loginItem": {
+    "defaultMessage": "Accedi",
+    "description": "Ítem del drawer per obrir el modal de login"
+  },
+  "features.backend.auth.saveDocument": {
+    "defaultMessage": "Salva nel cloud",
+    "description": "Ítem del drawer per desar el document al backend"
+  },
+  "features.backend.auth.loadDocument": {
+    "defaultMessage": "Carica dal cloud",
+    "description": "Ítem del drawer per carregar un document del backend"
+  },
+  "features.backend.auth.logout": {
+    "defaultMessage": "Esci",
+    "description": "Ítem del drawer per tancar la sessió"
+  },
+  "features.backend.auth.documentSaved": {
+    "defaultMessage": "Documento salvato nel cloud",
+    "description": "Missatge de confirmació quan el document es desa al backend"
+  },
+  "features.backend.auth.documentLoaded": {
+    "defaultMessage": "Documento caricato",
+    "description": "Missatge de confirmació quan es carrega un document del backend"
+  },
+  "features.backend.auth.loadDocumentTitle": {
+    "defaultMessage": "Carica un documento",
+    "description": "Títol del modal de càrrega de documents del backend"
+  },
+  "features.backend.auth.noDocuments": {
+    "defaultMessage": "Non hai documenti salvati",
+    "description": "Missatge quan l'usuari no té documents al backend"
+  },
+  "features.backend.auth.deleteDocument": {
+    "defaultMessage": "Elimina",
+    "description": "Botó per eliminar un document del backend"
+  },
+  "features.backend.auth.loadAction": {
+    "defaultMessage": "Carica",
+    "description": "Botó per carregar un document seleccionat del backend"
+  },
   "features.backend.auth.error.INVALID_CREDENTIALS": {
     "defaultMessage": "Indirizzo e-mail o password errati",
     "description": "Error de login: credencials incorrectes"


### PR DESCRIPTION
Add missing auth modal keys (login/register titles, form labels, buttons, document actions) to French and Italian language files.